### PR TITLE
fix: do not encode messages to prompt

### DIFF
--- a/src/podman_ai_lab_stack/podman_ai_lab.py
+++ b/src/podman_ai_lab_stack/podman_ai_lab.py
@@ -190,18 +190,10 @@ class PodmanAILabInferenceAdapter(Inference, ModelsProtocolPrivate):
 
         input_dict = {}
         media_present = request_has_media(request)
-        llama_model = request.model
         if isinstance(request, ChatCompletionRequest):
-            if media_present or not llama_model:
-                contents = [await convert_message_to_openai_dict_for_podman_ai_lab(m) for m in request.messages]
-                # flatten the list of lists
-                input_dict["messages"] = [item for sublist in contents for item in sublist]
-            else:
-                input_dict["raw"] = True
-                input_dict["prompt"] = await chat_completion_request_to_prompt(
-                    request,
-                    llama_model,
-                )
+            contents = [await convert_message_to_openai_dict_for_podman_ai_lab(m) for m in request.messages]
+            # flatten the list of lists
+            input_dict["messages"] = [item for sublist in contents for item in sublist]
         else:
             assert not media_present, "Ollama does not support media for Completion requests"
             input_dict["prompt"] = await completion_request_to_prompt(request)


### PR DESCRIPTION
The AI Lab provider was encoding into a llama-compatible prompt (using special tokens, for example `<|begin_of_text|><|start_header_id|>user<|end_header_id|>What is France's capital?<|eot_id|><|start_header_id|>assistant<|end_header_id|>`) the messages, instead of passing the messages as is to the AI Lab API

Because of this, AI Lab API was passing the llama-compatible prompt as a simple text prompt, which was encoded again, causing the model to respond with sush special tokens in the response

This PR removes the encoding in llama-compatible prompt.
